### PR TITLE
Add ELASTICSEARCH_URL env var

### DIFF
--- a/lib/kagu.rb
+++ b/lib/kagu.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'active_support'
 require 'active_record'
+require 'elasticsearch/model'
 require 'pry'
 
 module Kagu

--- a/lib/kagu/bootstrap.rb
+++ b/lib/kagu/bootstrap.rb
@@ -6,7 +6,15 @@ module Kagu
     include Singleton
 
     def self.bootstrap
+      instance.configure_elasticsearch_client
       instance.link_activerecord_models
+    end
+
+    def configure_elasticsearch_client
+      ::Elasticsearch::Model.client = ::Elasticsearch::Client.new(
+        host: ENV.fetch('ELASTICSEARCH_URL', 'localhost:9200'),
+        log: true
+      )
     end
 
     def link_activerecord_models

--- a/lib/kagu/models.rb
+++ b/lib/kagu/models.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'elasticsearch/model'
-
 module Kagu
   module Models
     extend ActiveSupport::Autoload

--- a/lib/kagu/version.rb
+++ b/lib/kagu/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Kagu
-  VERSION = '0.0.21'
+  VERSION = '0.0.22'
 end


### PR DESCRIPTION
- Get connection URL from environment variable since we're not running it locally on Heroku