### PR TITLE
145004659: Deprecate an old API

### DIFF
--- a/lib/kagu/adapters/s3.rb
+++ b/lib/kagu/adapters/s3.rb
@@ -14,12 +14,6 @@ module Kagu
                        :file_to_buffer, :upload_file, :object_by_key
       end
 
-      # TODO: deprecate this
-      def file_to_buffer(s3_url)
-        object_output = bucket.object(s3_url).get
-        object_output.body if object_output.present?
-      end
-
       def object_by_key(key)
         bucket.object(key)
       end

--- a/lib/kagu/version.rb
+++ b/lib/kagu/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Kagu
-  VERSION = '0.3.2'
+  VERSION = '0.4.0'
 end

--- a/spec/lib/kagu/adapters/s3_spec.rb
+++ b/spec/lib/kagu/adapters/s3_spec.rb
@@ -41,16 +41,5 @@ describe Kagu::Adapters::S3 do
         expect(object).to receive(:upload_file).with(temp_file.path)
       end
     end
-
-    context '.file_to_buffer' do
-      let(:s3_url) { 'foo/bar/baz.avi' }
-
-      after { described_class.file_to_buffer(s3_url) }
-
-      it 'should invoke the correct methods' do 
-        expect(bucket).to receive(:object).with(s3_url).and_return(object)
-        expect(object).to receive(:get)
-      end
-    end
   end
 end


### PR DESCRIPTION
- Removes the old `#file_to_buffer` method from adapter, semver to `0.4.0`